### PR TITLE
Extra chat additions: blinking cursor and new GAMEEVENT_CHAT event type

### DIFF
--- a/docs/zandronum-history.txt
+++ b/docs/zandronum-history.txt
@@ -32,6 +32,7 @@
 +	- Added new SBARINFO commands: IfSpectator [not] [dead] and IfSpying [not] that execute a sub block if the local player is (not) a (dead) spectator, or (not) spying on another player respectively. [Kaminsky]
 +	- Added ACS functions: ExecuteClientScript and NamedExecuteClientScript which let the server execute clientside scripts for only one client as opposed to everyone. This allows net traffic to be greatly optimized, such that the server only sends out commands to the client(s) that matter. [Kaminsky]
 +	- Added ACS functions: SendNetworkString and NamedSendNetworkString, allowing strings to be sent from the server to the client(s) and vice versa, which are passed as the first argument of script to also be executed. Note that sending strings from client to server works just like puking scripts and there's no guarantee they are sent to the server successfully. [Kaminsky]
++	- Added a new EVENT script type: GAMEEVENT_CHAT that triggers when a non-private chat message is sent. Use this in conjunction with the ACS function: GetChatMessage(int player, int offset) to get the last chat message received by the player (or the server if -1 is passed). [Kaminsky]
 -	- Fixed: Bots tries to jump to reach item when sv_nojump is true. [sleep]
 -	- Fixed: ACS function SetSkyScrollSpeed didn't work online. [Edward-san]
 -	- Fixed: color codes in callvote reasons weren't terminated properly. [Dusk]

--- a/src/bots.cpp
+++ b/src/bots.cpp
@@ -88,6 +88,7 @@
 #include "p_trace.h"
 #include "sbar.h"
 #include "doomerrors.h"
+#include "chat.h"
 
 //*****************************************************************************
 //	VARIABLES
@@ -590,6 +591,9 @@ void BOTS_RemoveBot( ULONG ulPlayerIdx, bool bExitMsg )
 		else
 			SERVER_Printf( "%s left the game.\n", players[ulPlayerIdx].userinfo.GetName() );
 	}
+
+	// [AK] Clear all the saved chat messages this bot said.
+	CHAT_ClearChatMessages( ulPlayerIdx );
 
 	// [BB] Morphed bots need to be unmorphed before disconnecting.
 	if (players[ulPlayerIdx].morphTics)

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -134,6 +134,9 @@ static	ULONG	g_ulChatPlayer = 0;
 // [AK] A ticker that's used for controlling the blink of the cursor.
 static	ULONG	g_ulChatTicker = 0;
 
+// [AK] A collection of previously sent chat message from each player plus the server.
+static	RingBuffer<FString, MAX_SAVED_MESSAGES> g_SavedChatMessages[MAXPLAYERS + 1];
+
 //*****************************************************************************
 //	CONSOLE VARIABLES
 
@@ -851,6 +854,28 @@ ULONG CHAT_GetChatMode( void )
 
 //*****************************************************************************
 //
+const char *CHAT_GetChatMessage( ULONG ulPlayer, ULONG ulOffset )
+{
+	FString message = g_SavedChatMessages[ulPlayer].getOldestEntry( ulOffset );
+	return ( message.GetChars( ));
+}
+
+//*****************************************************************************
+//
+void CHAT_AddChatMessage( ULONG ulPlayer, const char *pszString )
+{
+	g_SavedChatMessages[ulPlayer].put( pszString );
+}
+
+//*****************************************************************************
+//
+void CHAT_ClearChatMessages( ULONG ulPlayer )
+{
+	g_SavedChatMessages[ulPlayer].clear();
+}
+
+//*****************************************************************************
+//
 void CHAT_PrintChatString( ULONG ulPlayer, ULONG ulMode, const char *pszString )
 {
 	ULONG		ulChatLevel = 0;
@@ -980,13 +1005,18 @@ void CHAT_PrintChatString( ULONG ulPlayer, ULONG ulMode, const char *pszString )
 			S_Sound( CHAN_VOICE | CHAN_UI, "misc/chat", 1, ATTN_NONE );
 	}
 
-	BOTCMD_SetLastChatString( pszString );
-	BOTCMD_SetLastChatPlayer( PLAYER_IsValidPlayer( ulPlayer ) ? players[ulPlayer].userinfo.GetName() : "" );
-
+	// [AK] Only save chat messages for non-private chat messages.
+	if (( ulMode != CHATMODE_PRIVATE_SEND ) && ( ulMode != CHATMODE_PRIVATE_RECEIVE ))
 	{
-		ULONG	ulIdx;
+		g_SavedChatMessages[ulPlayer].put( pszString );
 
-		for ( ulIdx = 0; ulIdx < MAXPLAYERS; ulIdx++ )
+		// [AK] Trigger an event script indicating that a chat message was received.
+		GAMEMODE_HandleEvent( GAMEEVENT_CHAT, 0, ulPlayer != MAXPLAYERS ? ulPlayer : -1, ulMode - CHATMODE_GLOBAL );
+
+		BOTCMD_SetLastChatString( pszString );
+		BOTCMD_SetLastChatPlayer( PLAYER_IsValidPlayer( ulPlayer ) ? players[ulPlayer].userinfo.GetName() : "" );
+
+		for ( ULONG ulIdx = 0; ulIdx < MAXPLAYERS; ulIdx++ )
 		{
 			if ( playeringame[ulIdx] == false )
 				continue;

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -856,8 +856,7 @@ ULONG CHAT_GetChatMode( void )
 //
 const char *CHAT_GetChatMessage( ULONG ulPlayer, ULONG ulOffset )
 {
-	FString message = g_SavedChatMessages[ulPlayer].getOldestEntry( ulOffset );
-	return ( message.GetChars( ));
+	return ( g_SavedChatMessages[ulPlayer].getOldestEntry( ulOffset ).GetChars( ));
 }
 
 //*****************************************************************************

--- a/src/chat.h
+++ b/src/chat.h
@@ -59,6 +59,9 @@
 // Maximum size of the chat buffer.
 #define	MAX_CHATBUFFER_LENGTH		128
 
+// [AK] Maximum saved chat messages for each player.
+#define MAX_SAVED_MESSAGES		5
+
 //*****************************************************************************
 typedef enum
 {
@@ -75,13 +78,16 @@ typedef enum
 //*****************************************************************************
 //	PROTOTYPES
 
-void	CHAT_Construct( void );
-void	CHAT_Tick( void );
-bool	CHAT_Input( event_t *pEvent );
-void	CHAT_Render( void );
+void		CHAT_Construct( void );
+void		CHAT_Tick( void );
+bool		CHAT_Input( event_t *pEvent );
+void		CHAT_Render( void );
 
-ULONG	CHAT_GetChatMode( void );
-void	CHAT_PrintChatString( ULONG ulPlayer, ULONG ulMode, const char *pszString );
+ULONG		CHAT_GetChatMode( void );
+const char	*CHAT_GetChatMessage( ULONG ulPlayer, ULONG ulOffset ); // [AK]
+void		CHAT_AddChatMessage( ULONG ulPlayer, const char *pszString ); // [AK]
+void		CHAT_ClearChatMessages( ULONG ulPlayer ); // [AK]
+void		CHAT_PrintChatString( ULONG ulPlayer, ULONG ulMode, const char *pszString );
 
 //*****************************************************************************
 //  EXTERNAL CONSOLE VARIABLES

--- a/src/cl_main.cpp
+++ b/src/cl_main.cpp
@@ -4452,6 +4452,9 @@ void ServerCommands::DisconnectPlayer::Execute()
 
 	playeringame[player - players] = false;
 
+	// [AK] Clear all the saved chat messages this player said.
+	CHAT_ClearChatMessages( player - players );
+
 	// Zero out all the player information.
 	PLAYER_ResetPlayerData( player );
 

--- a/src/cl_main.cpp
+++ b/src/cl_main.cpp
@@ -393,7 +393,13 @@ void CLIENT_ClearAllPlayers( void )
 
 		// Zero out all the player information.
 		PLAYER_ResetPlayerData( &players[ulIdx] );
+
+		// [AK] Clear out saved chat messages from the players.
+		CHAT_ClearChatMessages( ulIdx );
 	}
+
+	// [AK] Also clear out saved chat messages from the server.
+	CHAT_ClearChatMessages( MAXPLAYERS );
 }
 
 //*****************************************************************************

--- a/src/d_player.h
+++ b/src/d_player.h
@@ -802,6 +802,7 @@ bool	PLAYER_IsAliveOrCanRespawn( player_t *pPlayer );
 void	PLAYER_RemoveFriends( const ULONG ulPlayer );
 void	PLAYER_LeavesGame( const ULONG ulPlayer );
 void	PLAYER_ClearEnemySoundFields( const ULONG ulPlayer );
+bool	PLAYER_NameMatchesServer( const FString &Name );
 bool	PLAYER_NameUsed( const FString &Name, const ULONG ulIgnorePlayer = MAXPLAYERS );
 FString	PLAYER_GenerateUniqueName( void );
 

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -106,6 +106,7 @@
 #include "gi.h"
 #include "survival.h"
 #include "network/nettraffic.h"
+#include "chat.h"
 #include <set> // [CK] For CCMD listmusic
 
 #include "g_hub.h"
@@ -428,6 +429,10 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 
 	// [BC] Clear out the called vote if one is taking place.
 	CALLVOTE_ClearVote( );
+
+	// [AK] Clear out the saved chat messages from all players and the server.
+	for ( ULONG ulPlayer = 0; ulPlayer <= MAXPLAYERS; ulPlayer++ )
+		CHAT_ClearChatMessages( ulPlayer );
 
 	if (StatusBar != NULL)
 	{

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -431,8 +431,11 @@ void G_InitNew (const char *mapname, bool bTitleLevel)
 	CALLVOTE_ClearVote( );
 
 	// [AK] Clear out the saved chat messages from all players and the server.
-	for ( ULONG ulPlayer = 0; ulPlayer <= MAXPLAYERS; ulPlayer++ )
-		CHAT_ClearChatMessages( ulPlayer );
+	if ( NETWORK_InClientMode( ) == false )
+	{
+		for ( ULONG ulPlayer = 0; ulPlayer <= MAXPLAYERS; ulPlayer++ )
+			CHAT_ClearChatMessages( ulPlayer );
+	}
 
 	if (StatusBar != NULL)
 	{

--- a/src/gamemode.h
+++ b/src/gamemode.h
@@ -105,6 +105,7 @@ typedef enum
 	GAMEEVENT_ROUND_STARTS,
 	GAMEEVENT_ROUND_ENDS,
 	GAMEEVENT_ROUND_ABORTED,
+	GAMEEVENT_CHAT,
 } GAMEEVENT_e;
 
 //*****************************************************************************

--- a/src/networkshared.h
+++ b/src/networkshared.h
@@ -557,6 +557,10 @@ public:
 	{
 		clear();
 	}
+	~RingBuffer ( )
+	{
+		clear();
+	}
 	void clear ( )
 	{
 		if ( _data != NULL )

--- a/src/networkshared.h
+++ b/src/networkshared.h
@@ -559,7 +559,7 @@ public:
 	}
 	~RingBuffer ( )
 	{
-		clear();
+		delete[] _data;
 	}
 	void clear ( )
 	{

--- a/src/networkshared.h
+++ b/src/networkshared.h
@@ -559,6 +559,9 @@ public:
 	}
 	void clear ( )
 	{
+		if ( _data != NULL )
+			delete[] _data;
+
 		_data = new DataType[Length];
 		_position = 0;
 	}

--- a/src/networkshared.h
+++ b/src/networkshared.h
@@ -549,7 +549,7 @@ public:
 template<typename DataType, int Length>
 class RingBuffer
 {
-	DataType _data[Length];
+	DataType* _data;
 	// Position of the entry that will be overwritten next AKA the oldest entry.
 	unsigned int _position;
 public:
@@ -559,7 +559,7 @@ public:
 	}
 	void clear ( )
 	{
-		memset( _data, 0, sizeof( _data ));
+		_data = new DataType[Length];
 		_position = 0;
 	}
 	void put ( DataType Entry )

--- a/src/p_acs.cpp
+++ b/src/p_acs.cpp
@@ -89,6 +89,7 @@
 #include "za_database.h"
 #include "cl_commands.h"
 #include "cl_main.h"
+#include "chat.h"
 
 #include "g_shared/a_pickups.h"
 
@@ -5354,6 +5355,7 @@ enum EACSFunctions
 	ACSF_NamedExecuteClientScript,
 	ACSF_SendNetworkString,
 	ACSF_NamedSendNetworkString,
+	ACSF_GetChatMessage,
 
 	// ZDaemon
 	ACSF_GetTeamScore = 19620,	// (int team)
@@ -7616,6 +7618,20 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 				const int client = argCount > 2 ? args[2] : -1;
 
 				return SendNetworkString( activeBehavior, activator, -scriptName, args[1], client );
+			}
+
+		case ACSF_GetChatMessage:
+			{
+				const int offset = ( MAX_SAVED_MESSAGES - 1 ) - clamp<int>( args[1], 0, MAX_SAVED_MESSAGES - 1 );
+
+				// [AK] Get the chat message from the server via RCON.
+				if ( args[0] < 0 )
+					return GlobalACSStrings.AddString( CHAT_GetChatMessage( MAXPLAYERS, offset ) );
+				// [AK] Only get chat messages from valid players.
+				else if ( PLAYER_IsValidPlayer( args[0] ) )
+					return GlobalACSStrings.AddString( CHAT_GetChatMessage( args[0], offset ) );
+
+				return GlobalACSStrings.AddString( "" );
 			}
 
 		case ACSF_GetActorFloorTexture:

--- a/src/p_interaction.cpp
+++ b/src/p_interaction.cpp
@@ -3279,6 +3279,16 @@ void PLAYER_ClearEnemySoundFields( const ULONG ulPlayer )
 
 //*****************************************************************************
 //
+bool PLAYER_NameMatchesServer( const FString &Name )
+{
+	FString nameNoColor = Name;
+	V_RemoveColorCodes( nameNoColor );
+
+	return (( !nameNoColor.CompareNoCase( "server" )) || ( !nameNoColor.CompareNoCase( "<server>" )));
+}
+
+//*****************************************************************************
+//
 bool PLAYER_NameUsed( const FString &Name, const ULONG ulIgnorePlayer )
 {
 	FString nameNoColor = Name;

--- a/src/sv_main.cpp
+++ b/src/sv_main.cpp
@@ -1121,10 +1121,18 @@ void SERVER_SendChatMessage( ULONG ulPlayer, ULONG ulMode, const char *pszString
 	pszString = cleanedChatString.GetChars();
 
 	// [AK] Check if we're sending a private message.
-	if( ulMode == CHATMODE_PRIVATE_SEND )
+	if ( ulMode == CHATMODE_PRIVATE_SEND )
+	{
 		SERVERCOMMANDS_PrivateSay( ulPlayer, ulReceiver, pszString, bFordidChatToPlayers );
+	}
 	else
+	{
 		SERVERCOMMANDS_PlayerSay( ulPlayer, pszString, ulMode, bFordidChatToPlayers );
+		CHAT_AddChatMessage( ulPlayer, pszString );
+
+		// [AK] Trigger an event script indicating that a chat message was received.
+		GAMEMODE_HandleEvent( GAMEEVENT_CHAT, 0, ulPlayer != MAXPLAYERS ? ulPlayer : -1, ulMode - CHATMODE_GLOBAL );
+	}
 
 	// [AK] Don't log private messages that aren't sent to/from the server.
 	if (( ulMode == CHATMODE_PRIVATE_SEND ) && ( ulPlayer != MAXPLAYERS ) && ( ulReceiver != MAXPLAYERS ))
@@ -2874,6 +2882,9 @@ void SERVER_DisconnectClient( ULONG ulClient, bool bBroadcast, bool bSaveInfo )
 
 	// [RK] Disconnectd players need their vote removed/cancelled.
 	CALLVOTE_DisconnectedVoter( ulClient );
+
+	// [AK] Clear all the saved chat messages this player said.
+	CHAT_ClearChatMessages( ulClient );
 
 	// [BB] Morphed players need to be unmorphed before disconnecting.
 	if (players[ulClient].morphTics)

--- a/src/sv_main.cpp
+++ b/src/sv_main.cpp
@@ -2016,16 +2016,28 @@ bool SERVER_GetUserInfo( BYTESTREAM_s *pByteStream, bool bAllowKick, bool bEnfor
 				kickReason = "User name contains illegal characters." ;
 			}
 
+			FString message;
+
+			// [AK] Don't allow players to name themselves as "server" in order to avert
+			// any potential impersonation of the server.
+			if ( PLAYER_NameMatchesServer ( value ) )
+			{
+				message.Format ( "You can't name yourself as the server. " );
+				bOverriddenName = true;
+			}
 			// [BB] Check whether the requested name is already in use.
 			// If so, give the player a generic unused name and inform the client.
-			if ( PLAYER_NameUsed ( value, g_lCurrentClient ) )
+			else if ( PLAYER_NameUsed ( value, g_lCurrentClient ) )
 			{
-				FString message;
 				message.Format ( "The name '%s' is already in use. ", value.GetChars() );
+				bOverriddenName = true;
+			}
+
+			if ( bOverriddenName )
+			{
 				value = PLAYER_GenerateUniqueName();
 				message.AppendFormat ( "You are renamed to '%s'.\n", value.GetChars() );
 				SERVERCOMMANDS_PrintMid( message, true, g_lCurrentClient, SVCF_ONLYTHISCLIENT );
-				bOverriddenName = true;
 			}
 
 			// [BB] It's extremely critical that we NEVER use the uncleaned player name!


### PR DESCRIPTION
These are some extra commits I created, that add a few things to the chat.

- Players cannot name themselves as "server" in online games anymore. This averts potential impersonation of the server and the ambiguous case that if someone tries sending a private message using `sayto server`, whether the server or the player with the same name should be chosen.
- The chat cursor now blinks while the playing is creating a message. If they're typing or passing any input, the cursor remains visible. This always takes into account the width of the '_' character, whether it's visible or not, which does make the implementation somewhat complicated but necessary.
- I touched up and re-added the new EVENT type: GAMEEVENT_CHAT and the ACS function GetChatMessage( int player, int index ). Up to three chat messages from the player (or server) can be stored in memory, and modders can also pass an index between 0 and 2 to retrieve the corresponding chat message, with 0 being the newest and 2 being oldest. This is in case the local machine, whether it's the client or the server, receives more than one chat message from the sender in a single tic, which means the last chat message will replace the older ones.
