### PR TITLE
Backport morph death code from GZDoom 2.1.0

### DIFF
--- a/src/g_shared/a_morph.cpp
+++ b/src/g_shared/a_morph.cpp
@@ -14,6 +14,7 @@
 #include "farchive.h"
 // [BB] New #includes.
 #include "sv_commands.h"
+#include "p_enemy.h"
 
 static FRandom pr_morphmonst ("MorphMonster");
 
@@ -586,19 +587,26 @@ bool P_MorphedDeath(AActor *actor, AActor **morphed, int *morphedstyle, int *mor
 	if (actor->GetClass()->IsDescendantOf(RUNTIME_CLASS(AMorphedMonster)))
 	{
 		AMorphedMonster *fakeme = static_cast<AMorphedMonster *>(actor);
-		if ((fakeme->UnmorphTime) &&
-			(fakeme->MorphStyle & MORPH_UNDOBYDEATH) &&
-			(fakeme->UnmorphedMe))
+		AActor *realme = fakeme->UnmorphedMe;
+		if (realme != NULL)
 		{
-			AActor *realme = fakeme->UnmorphedMe;
-			int realstyle = fakeme->MorphStyle;
-			int realhealth = fakeme->health;
-			if (P_UndoMonsterMorph(fakeme, !!(fakeme->MorphStyle & MORPH_UNDOBYDEATHFORCED)))
+			if ((fakeme->UnmorphTime) &&
+				(fakeme->MorphStyle & MORPH_UNDOBYDEATH))
 			{
-				*morphed = realme;
-				*morphedstyle = realstyle;
-				*morphedhealth = realhealth;
-				return true;
+				int realstyle = fakeme->MorphStyle;
+				int realhealth = fakeme->health;
+				if (P_UndoMonsterMorph(fakeme, !!(fakeme->MorphStyle & MORPH_UNDOBYDEATHFORCED)))
+				{
+					*morphed = realme;
+					*morphedstyle = realstyle;
+					*morphedhealth = realhealth;
+					return true;
+				}
+			}
+			if (realme->flags4 & MF4_BOSSDEATH)
+			{
+				realme->health = 0;	// make sure that A_BossDeath considers it dead.
+				CALL_ACTION(A_BossDeath, realme);
 			}
 		}
 		fakeme->flags3 |= MF3_STAYMORPHED; // moved here from AMorphedMonster::Die()


### PR DESCRIPTION
Backported the morph death code from GZDoom 2.1.0 to fix ticket 0003831. I made sure to test this online as well.