### PR TITLE
Ultimate DOOM XBOX version support like in GZDoom

### DIFF
--- a/wadsrc/static/iwadinfo.txt
+++ b/wadsrc/static/iwadinfo.txt
@@ -237,6 +237,20 @@ IWad
 
 IWad
 {
+	Name = "DOOM: XBox Edition"
+	Autoname = "doom.id.doom1.ultimate.xbox"
+	Game = "Doom"
+	Config = "Doom"
+	Mapinfo = "mapinfo/doomxbox.txt"
+	Compatibility = "Shorttex"
+	MustContain = "E1M1","E2M1","E2M2","E2M3","E2M4","E2M5","E2M6","E2M7","E2M8","E2M9",
+		          "E3M1","E3M2","E3M3","E3M4","E3M5","E3M6","E3M7","E3M8","E3M9",
+		          "DPHOOF","BFGGA0","HEADA1","CYBRA1","SPIDA1D1", "E4M2", "E1M10", "SEWERS"
+	BannerColors = "18 18 18", "a8 a8 a8"
+}
+
+IWad
+{
 	Name = "The Ultimate DOOM"
 	Autoname = "Doom1"
 	Game = "Doom"

--- a/wadsrc/static/mapinfo/doomxbox.txt
+++ b/wadsrc/static/mapinfo/doomxbox.txt
@@ -1,0 +1,24 @@
+// MAPINFO for Doom: XBox Edition
+include "mapinfo/ultdoom.txt"
+
+map E1M1 lookup "HUSTR_E1M1"
+{
+	levelnum = 1
+	titlepatch = "WILV00"
+	next = "E1M2"
+	secretnext = "E1M10"
+	sky1 = "SKY1"
+	cluster = 1
+	par = 30
+	music = "$MUSIC_E1M1"
+}
+
+map E1M10 lookup "HUSTR_E1M10"
+{
+	titlepatch = "SEWERS"
+	next = "E1M2"
+	secretnext = "E1M2"
+	sky1 = "SKY1"
+	cluster = 1
+	music = "$MUSIC_E2M1"
+}


### PR DESCRIPTION
When loading the xbox wad it displays the correct title and going from E1M1 to E1M10 functions properly
The files are slightly edited from the GZDoom repository