### PR TITLE
Add the CVar sv_printconnectionmessages, which controls whether messages and errors for clients not completely connected to the server are printed to the server console.

### DIFF
--- a/docs/zandronum-history.txt
+++ b/docs/zandronum-history.txt
@@ -15,6 +15,7 @@
 3.2.1
 -----
 
++	- Add the CVar sv_printconnectionmessages, which controls whether messages and errors for clients not completely connected to the server are printed to the server console. [Sean]
 -	- Fixed: some of the sounds that a skin was using weren't playing correctly. [AKMDM]
 -	- Fixed: spectators were unable to pass through teleporters while using the unrestricted spectator mode. [AKMDM]
 -	- Fixed: weapons with the NOLMS flag were no longer given to players after they already spawned in (T)LMS, particularly morph weapons. [AKMDM]


### PR DESCRIPTION
Someone needs to test PRs by git, I guess...

This adds `sv_printconnectionmessages`, which controls whether messages about clients who are not currently completely connected to the server are printed to the server console. This is because the messages aren't really that useful most of the time and are even sometimes abused to fill a server console with spam.