### PR TITLE
Added workflows for CI using GitHub Actions.

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,0 +1,78 @@
+name: Linux build
+
+on: [push, pull_request]
+
+env:
+  FMOD_VER: 44464
+  FMOD_SOVER: 4.44.64
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        build_type: [Release]
+        # This is just so the job and artefact names look nicer...
+        serveronly: ["", "SERVERONLY"]
+        include:
+          - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+        exclude:
+          - os: ubuntu-24.04-arm
+            serveronly: ""
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Install dependencies for Linux
+      shell: bash
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install g++ make cmake libsdl1.2-dev mercurial zlib1g-dev libbz2-dev libjpeg-dev libfluidsynth-dev libgtk2.0-dev timidity nasm libgl1-mesa-dev libssl-dev tar libglew-dev wget libopus-dev
+        
+        if [[ "${{ matrix.serveronly }}" == "" ]]; then
+          wget https://github.com/DrinkyBird/zan-ci-deps/releases/download/ci-dependencies/fmodapi${FMOD_VER}linux.tar.gz
+          tar xf fmodapi${FMOD_VER}linux.tar.gz
+          echo "FMOD_INCLUDE_DIR=${PWD}/fmodapi${FMOD_VER}linux/api/inc" >> $GITHUB_ENV
+          echo "FMOD_LIBRARY=${PWD}/fmodapi${FMOD_VER}linux/api/lib/libfmodex64-${FMOD_SOVER}.so" >> $GITHUB_ENV
+        fi
+
+    - name: Configure CMake
+      run: >
+        if [[ "${{ matrix.serveronly }}" == "SERVERONLY" ]]; then export SERVERONLY=ON; fi
+        
+        cmake -B ${{ steps.strings.outputs.build-output-dir }} -S ${{ github.workspace }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DSERVERONLY=${SERVERONLY}
+        -DRELEASE_WITH_DEBUG_FILE=ON
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} -j $(nproc)
+
+    - name: Create package
+      shell: bash
+      run: |
+        mkdir package
+        if [[ "${{ runner.os }}" == 'Linux' ]]; then
+          cp ${{ steps.strings.outputs.build-output-dir }}/zandronum* package
+          cp ${{ steps.strings.outputs.build-output-dir }}/*.pk3 package
+          cp ${{ steps.strings.outputs.build-output-dir }}/*.so package || true
+          cp ${FMOD_LIBRARY} package || true
+        fi
+
+    - name: Upload artefacts
+      uses: actions/upload-artifact@v4
+      with:
+        path: package
+        name: ${{ matrix.os }} ${{ matrix.build_type }} ${{ matrix.serveronly }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,82 @@
+name: Windows build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: windows-2022
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: [Release]
+        platform: ["Win32", "x64"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+        echo "deps-dir=${{ github.workspace }}/deps" >> "$GITHUB_OUTPUT"
+
+    - name: Install dependencies for Windows
+      shell: pwsh
+      if: runner.os == 'Windows'
+      run: |
+        Invoke-WebRequest -Outfile 'deps.zip' 'https://github.com/DrinkyBird/zan-ci-deps/releases/download/ci-dependencies/zan-windows-deps.zip'
+        Expand-Archive 'deps.zip' -DestinationPath '${{ steps.strings.outputs.deps-dir }}'
+
+    - name: Configure CMake
+      shell: pwsh
+      run: |
+        $bits = 32;
+        $sslArch = 'x86';
+        $fmodArch = '';
+        If ( '${{ matrix.platform }}' -eq 'x64' ) {
+            $bits = 64;
+            $sslArch = 'x64';
+            $fmodArch = '64';
+        }
+        
+        # see src/CMakeLists.txt, it takes an env variable hint for finding DirectX
+        $env:DXSDK_DIR = "${{ steps.strings.outputs.deps-dir }}\dxsdk" ;
+        
+        # We need it for the artefacts later
+        echo "FMOD_DLL=${{ steps.strings.outputs.deps-dir }}\fmod\api\fmodex${fmodArch}.dll" >> $env:GITHUB_ENV ;
+        
+        & cmake -B "${{ steps.strings.outputs.build-output-dir }}" -S "${{ github.workspace }}" `
+            -A "${{ matrix.platform }}" `
+            -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" `
+            -DRELEASE_WITH_DEBUG_FILE=ON `
+            -DOPUS_INCLUDE_DIR="${{ steps.strings.outputs.deps-dir }}\opus\include" `
+            -DOPUS_LIBRARIES="${{ steps.strings.outputs.deps-dir }}\opus\lib${bits}\opus.lib" `
+            -DOPENSSL_INCLUDE_DIR="${{ steps.strings.outputs.deps-dir }}\openssl${bits}\include" `
+            -DLIB_EAY_DEBUG="${{ steps.strings.outputs.deps-dir }}\openssl${bits}\lib\VC\${sslArch}\MTd\libcrypto_static.lib" `
+            -DLIB_EAY_RELEASE="${{ steps.strings.outputs.deps-dir }}\openssl${bits}\lib\VC\${sslArch}\MT\libcrypto_static.lib" `
+            -DSSL_EAY_DEBUG="${{ steps.strings.outputs.deps-dir }}\openssl${bits}\lib\VC\${sslArch}\MTd\libssl_static.lib" `
+            -DSSL_EAY_RELEASE="${{ steps.strings.outputs.deps-dir }}\openssl${bits}\lib\VC\${sslArch}\MT\libssl_static.lib" `
+            -DFMOD_INCLUDE_DIR="${{ steps.strings.outputs.deps-dir }}\fmod\api\inc" `
+            -DFMOD_LIBRARY="${{ steps.strings.outputs.deps-dir }}\fmod\api\lib\fmodex${fmodArch}_vc.lib" `
+            -DNASM_PATH="${{ steps.strings.outputs.deps-dir }}\nasm\nasm.exe"
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Create package
+      shell: pwsh
+      run: |
+        mkdir package
+        cp ${{ steps.strings.outputs.build-output-dir }}\${{ matrix.build_type }}\*.exe package
+        cp ${{ steps.strings.outputs.build-output-dir }}\${{ matrix.build_type }}\*.pdb package
+        cp ${{ steps.strings.outputs.build-output-dir }}\${{ matrix.build_type }}\*.pk3 package
+        cp ${env:FMOD_DLL} package
+
+    - name: Upload artefacts
+      uses: actions/upload-artifact@v4
+      with:
+        path: package
+        name: ${{ matrix.platform }} ${{ matrix.build_type }}


### PR DESCRIPTION
Same jobs as on Heptapod basically, but adjusted for Actions and GitHub's provided runners. 

Probably the biggest caveat is that FMOD (for Linux) and the Windows dependencies are served from [a repo in my user](https://github.com/DrinkyBird/zan-ci-deps/releases/tag/ci-dependencies)... since the GH runners are actually containerised unlike the shell runner I host for us on Heptapod, it was the easiest way to get the deps in there. The repo should probably be moved out of my user into an organisation whenever we get one... I tried downloading FMOD from our mirror on zandronum.com but it failed; I imagine Azure is blocked since it's a source of AI scraper bots that were thrashing our site as of late.